### PR TITLE
Bump goreleaser action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@f82d6c1c344bcacabba2c841718984797f664a6b # v4.2.0
+        uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811 # v5.1.0
         with:
           args: release --clean
         env:


### PR DESCRIPTION
Bump `goreleaser-action` to `v5.1.0`

- `goreleaser-action v.4.2.0` uses latest (v2) `goreleaser` binary which is incompatible with current `.goreleaser.yml`
- `goreleaser-action v.5.1.0` locks the major version of goreleaser binary to `~> v1`